### PR TITLE
Fix local paths in ~/.vim

### DIFF
--- a/zen.vim
+++ b/zen.vim
@@ -20,10 +20,10 @@ function! zen#init() abort
         endif
         let s:installation_path = $HOME . '/.local/share/nvim/plugged'
     else
-        if !isdirectory($HOME . '.vim/plugged')
-            call mkdir($HOME . '.vim/plugged')
+        if !isdirectory($HOME . '/.vim/plugged')
+            call mkdir($HOME . '/.vim/plugged')
         endif
-        let s:installation_path = $HOME . '.vim/plugged'
+        let s:installation_path = $HOME . '/.vim/plugged'
     endif
 
     call s:define_commands()


### PR DESCRIPTION
Slight mistake in the `zen#init()` method that builds the paths incorrectly. This is the fix for it.

Closes #1 