### PR TITLE
Remove commands library for Python 3

### DIFF
--- a/zen.vim
+++ b/zen.vim
@@ -1,8 +1,8 @@
 " ==========================================================
 " Name:         vim-zen: Vim plugin manager
 " Maintainer:   Danish Prakash
-" HomePage:     https://github.com/prakashdanish/vim-zen
-" Version:      1.0.0
+" HomePage:     https://github.com/danishprakash/vim-zen
+" License:      MIT
 " ==========================================================
 
 
@@ -292,7 +292,7 @@ execute py_exe "<< EOF"
 import vim
 import time
 import threading
-import os
+import subprocess
 
 try:
     import queue
@@ -307,15 +307,8 @@ class ZenThread(threading.Thread):
         self.name = name
 
     def run(self):
-        pipe = os.popen('{ ' + self.cmd + '; } 2>&1', 'r')
-        output = pipe.read()
-        status = pipe.close()
-
-        if status is None:
-            status = 0
-        if text[-1:] == '\n': 
-            text = text[:-1]
-        
+        proc = subprocess.Popen(self.cmd, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        (status, output) = proc.communicate()
         self.queue.put((self.cmd, output, status, self.name))
 
 

--- a/zen.vim
+++ b/zen.vim
@@ -291,8 +291,8 @@ let py_exe = has('python') ? 'python' : 'python3'
 execute py_exe "<< EOF"
 import vim
 import time
-import commands
 import threading
+import os
 
 try:
     import queue
@@ -307,7 +307,15 @@ class ZenThread(threading.Thread):
         self.name = name
 
     def run(self):
-        (status, output) = commands.getstatusoutput(self.cmd)
+        pipe = os.popen('{ ' + self.cmd + '; } 2>&1', 'r')
+        output = pipe.read()
+        status = pipe.close()
+
+        if status is None:
+            status = 0
+        if text[-1:] == '\n': 
+            text = text[:-1]
+        
         self.queue.put((self.cmd, output, status, self.name))
 
 


### PR DESCRIPTION
The commands library has been removed in Python 3 ([see the docs](https://docs.python.org/2/library/commands.html)). For the sake of consistent behavior, I have replaced the call to the commands library with the [code called by the commands library](https://github.com/enthought/Python-2.7.3/blob/master/Lib/commands.py#L56).